### PR TITLE
Add function n_recovered

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VambBenchmarks"
 uuid = "63a9268e-b9e5-4a07-aba6-1f52d4878f75"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using VambBenchmarks
 meta = quote
     using VambBenchmarks
 
-    (ref, binning, genome, bin) = let
+    (path_to_ref_file, ref, binning, genome, bin) = let
         dir = joinpath(Base.pkgdir(VambBenchmarks), "files")
         path_to_ref_file = joinpath(dir, "ref.json")
         path_to_bins_file = joinpath(dir, "clusters.tsv")
@@ -12,7 +12,7 @@ meta = quote
         genome = first(sort!(collect(genomes(ref)); by=i -> i.name))
         bins = open(i -> Binning(i, ref), path_to_bins_file)
         bin = first(bins.bins)
-        (ref, bins, genome, bin)
+        (path_to_ref_file, ref, bins, genome, bin)
     end
 end
 

--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -269,6 +269,17 @@ P\R   0.6  0.7  0.8  0.9 0.95 0.99
 0.99   46   37   25    9    1    0
 ```
 
+You can also get the number of genomes or assemblies reconstructed at a given
+precision/recall level directly with `n_recovered`:
+
+```jldoctest walk
+julia> n_recovered(binning, 0.75, 0.9; assembly=true)
+55
+
+julia> n_recovered(binning, 0.66, 0.91; level=1)
+44
+```
+
 ## Bins
 The `Binning` object obviously contains our bins.
 Let's pick a particularly good bin:

--- a/src/VambBenchmarks.jl
+++ b/src/VambBenchmarks.jl
@@ -35,6 +35,9 @@ ifilter(f) = x -> Iterators.filter(f, x)
             Binning(io, ref)
         end
         print_matrix(IOBuffer(), bins)
+        n_recovered(bins, 0.4, 0.2)
+        n_recovered(bins, 0.4, 0.2; assembly=true)
+        n_recovered(bins, 0.4, 0.2; level=1)
     end
 end
 
@@ -58,6 +61,7 @@ export Sequence,
     is_plasmid,
     top_clade,
     gold_standard,
+    n_recovered,
     subset,
     subset!,
     f1,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,10 @@ end
     @test bins isa Binning
     @test nbins(bins) == 6
 
+    @test n_recovered(bins, 0.4, 0.71) == 1
+    @test n_recovered(bins, 0.4, 0.71; assembly=true) == 2
+    @test n_recovered(bins, 0.4, 0.71; assembly=true, level=2) == 1
+
     allgenomes = collect(genomes(ref))
     for (ir, recall) in enumerate(bins.recalls)
         for (ip, precision) in enumerate(bins.precisions)


### PR DESCRIPTION
This function allows the user to get the number of recovered genomes, clades or assemblies at a given level of recall and precision.