### PR TITLE
Add constructors from strings, and update walkthrough

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "VambBenchmarks"
 uuid = "63a9268e-b9e5-4a07-aba6-1f52d4878f75"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LazilyInitializedFields = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -12,6 +13,7 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
 AbstractTrees = "0.4.2"
+CodecZlib = "0.7"
 JSON3 = "1.9"
 LazilyInitializedFields = "1.2"
 PrecompileTools = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using VambBenchmarks
 meta = quote
     using VambBenchmarks
 
-    (path_to_ref_file, ref, binning, genome, bin) = let
+    (path_to_ref_file, path_to_bins_file, ref, binning, genome, bin) = let
         dir = joinpath(Base.pkgdir(VambBenchmarks), "files")
         path_to_ref_file = joinpath(dir, "ref.json")
         path_to_bins_file = joinpath(dir, "clusters.tsv")
@@ -12,7 +12,7 @@ meta = quote
         genome = first(sort!(collect(genomes(ref)); by=i -> i.name))
         bins = open(i -> Binning(i, ref), path_to_bins_file)
         bin = first(bins.bins)
-        (path_to_ref_file, ref, bins, genome, bin)
+        (path_to_ref_file, path_to_bins_file, ref, bins, genome, bin)
     end
 end
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,8 +10,8 @@ VambBenchmarks.jl is a package for efficient benchmarking and interactive explor
 ## Quickstart
 ```julia
 using VambBenchmarks
-ref =  open(i -> Reference(i), "files/ref.json")
-bins = open(i -> Binning(i, ref), "files/clusters.tsv")
+ref =  Reference("files/ref.json")
+bins = Binning("files/clusters.tsv", ref)
 print_matrix(bins)
 ```
 

--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -1,26 +1,28 @@
-# Example walkthrough
-_Note: This is run 2023-04-05 with commit AFTER bc99339_
+```@meta
+DocTestSetup = quote
+    using VambBenchmarks
 
-!!! danger
-    The documentation on this page uses a large dataset, and which is stored hosted online.
-    Hence, the code in this documentation is not tested, and may become outdated.
+    (path_to_ref_file, path_to_bins_file) = let
+        dir = joinpath(Base.pkgdir(VambBenchmarks), "files")
+        (joinpath(dir, "ref.json"), joinpath(dir, "clusters.tsv"))
+    end
+end
+```
+
+# Example walkthrough
 
 ## Loading the reference
 First, let's load the reference:
 ```jldoctest walk
 julia> using VambBenchmarks
 
-julia> ref_path = "/home/jakni/Downloads/vambdata/newref/ref_ptracker_megahit_Skin.json";
-
-julia> bins_path = "/home/jakni/Downloads/vambdata/newbins/megahit_skin.tsv";
-
-julia> ref = open(i -> Reference(i), ref_path)
+julia> ref = Reference(path_to_ref_file)
 Reference
-  Genomes:    2341
-  Sequences:  959970
-  Ranks:      9
-  Seq length: 200
-  Assembled:  25.0 %
+  Genomes:    3
+  Sequences:  11
+  Ranks:      3
+  Seq length: 10
+  Assembled:  66.8 %
 ```
 
 This gives us a few statistics about the reference:
@@ -31,27 +33,26 @@ This gives us a few statistics about the reference:
 * Total length of genomes that are assembled
 
 The genomes here contain both plasmids and organisms, and the sequence length of 200 bp is too short.
-Let's filter the reference using [`subset!`](@ref) to only retain organisms, and sequences of length 1500 or more:
+Let's filter the reference using [`subset!`](@ref) to only retain organisms, and sequences of length 25 or more:
 
 ```jldoctest walk
 julia> subset!(ref;
            genomes = is_organism,
-           sequences = s -> length(s) >= 1500
+           sequences = s -> length(s) >= 10
        )
 Reference
-  Genomes:    1394
-  Sequences:  118267
-  Ranks:      9
-  Seq length: 1500
-  Assembled:  16.1 %
+  Genomes:    2
+  Sequences:  11
+  Ranks:      3
+  Seq length: 10
+  Assembled:  91.3 %
 ```
 
 !!! note
     The function [`subset!`](@ref) will mutate the reference, whereas the function [`subset`](@ref)
     will create a new independent reference. At the moment, the latter is much slower.
 
-You can see we removed 7/8th of all sequences, but only 1/3rd of the total assembly length.
-We also removed almost half of all genomes (namely, all those that wasn't organisms).
+We removed a single genome, namely one labeled as virus.
 
 ## Genomes
 We can explore the genomes contained in the reference with the `genomes` function,
@@ -59,38 +60,20 @@ which returns an iterable of `Genome` (in this case, a `Set`):
 
 ```jldoctest walk; filter = r"\s+Genome\([A-Za-z0-9\.]+\)"
 julia> genomes(ref)
-Set{Genome} with 1394 elements:
-  Genome(OTU_97.34832.0)
-  Genome(OTU_97.33610.0)
-  Genome(OTU_97.39616.0)
-  Genome(OTU_97.23938.0)
-  Genome(OTU_97.24774.0)
-  Genome(OTU_97.36286.0)
-  Genome(OTU_97.6382.0)
-  Genome(OTU_97.33661.1)
-  Genome(OTU_97.37247.0)
-  Genome(OTU_97.1829.0)
-  Genome(OTU_97.6602.0)
-  Genome(OTU_97.44820.0)
-  Genome(OTU_97.24834.0)
-  Genome(OTU_97.44856.1)
-  Genome(OTU_97.3377.0)
-  Genome(OTU_97.19529.1)
-  Genome(OTU_97.32371.0)
-  Genome(OTU_97.45083.0)
-  Genome(OTU_97.15121.1)
-  ⋮
+Set{Genome} with 2 elements:
+  Genome(gA)
+  Genome(gB)
 ```
 
 Let's look at a `Genome` in more detail:
 ```jldoctest walk
-julia> genome, genome2 = sort!(collect(genomes(ref)); by=i -> i.name);
+julia> genome, genome2 = genomes(ref);
 
 julia> genome
-Genome "OTU_97.10046.0"
-  Parent:        "Staphylococcus capitis"
-  Genome size:   2474232
-  Assembly size: 9239 (0.4 %)
+Genome "gA"
+  Parent:        "D"
+  Genome size:   100
+  Assembly size: 88 (88.0 %)
   Sources:       1
   Flags:         1 (organism)
 ```
@@ -103,7 +86,7 @@ FlagSet with 1 element:
   VambBenchmarks.Flags.organism
 ```
 
-... in this case, this genome is an organism as opposed to a plasmid.
+... in this case, this genome is an organism as opposed to a plasmid or virus.
 You can see all possible flags with `instances(Flags.Flag)`.
 
 See also the helper functions [`is_organism`](@ref), [`is_virus`](@ref) and [`is_plasmid`](@ref)
@@ -113,27 +96,32 @@ The `genome` has one source - let's look at that
 
 ```jldoctest walk
 julia> source = only(genome.sources)
-Source "CP007601.1"
-genome:          Genome(OTU_97.10046.0)
-  Length:        2474232
-  Assembly size: 9239
-  Sequences:     2
+Source "subjA1"
+genome:          Genome(gA)
+  Length:        100
+  Assembly size: 88
+  Sequences:     6
 ```
 
-A `Source` is one of the genomic sequences that genomes are composed of. In the reference database where our genome
-was gotten from, it was assembled into a single contig called "CP001781.1" of 2.47 Mbp - presumably the complete, circular genome.
-We can see that 2 sequences map to this source, covering about 9.2 kbp.
+A `Source` is one of the genomic sequences that genomes are composed of.
+This is distinct from the assembled sequences that we will be binning - a `Source` represents the reference sequence,
+typically the full genome, assembled from a sequencing run on a clonal colony.
+For this genome, we can see it has a length of 100 bp, and that 5 sequences map to this source, covering 88 bp.
 
 We can get the sequences mapping to this source:
 
 ```jldoctest walk
 julia> source.sequences
-2-element Vector{Tuple{Sequence, UnitRange{Int64}}}:
- (Sequence("S13C8728", 2472), 2069906:2072374)
- (Sequence("S13C26910", 7349), 2085051:2091820)
+6-element Vector{Tuple{Sequence, UnitRange{Int64}}}:
+ (Sequence("s2", 40), 1:40)
+ (Sequence("s8", 25), 2:26)
+ (Sequence("s1", 25), 5:29)
+ (Sequence("s1", 25), 10:34)
+ (Sequence("s7", 20), 21:40)
+ (Sequence("s3", 50), 51:98)
 ```
 
-Where, e.g. the first entrance tells us that the sequence "S13C8728" with a length of 2472 maps to positions 2069906:2072374 (both inclusive).
+Where, e.g. the first entrance tells us that the sequence "s2" with a length of 40 maps to positions 1:40 (both inclusive).
 
 ## Clades
 Genomes are organised into a taxonomic hierarchy.
@@ -142,21 +130,17 @@ Let's look at another genome:
 
 ```jldoctest walk
 julia> genome2
-Genome "OTU_97.10083.0"
-  Parent:        "Moraxella bovoculi"
-  Genome size:   2220786
-  Assembly size: 0 (0.0 %)
-  Sources:       1
+Genome "gB"
+  Parent:        "D"
+  Genome size:   50
+  Assembly size: 49 (98.0 %)
+  Sources:       2
   Flags:         1 (organism)
 
 julia> clade = genome2.parent
-Species "Moraxella bovoculi", 6 genomes
-├─ Genome(OTU_97.36230.1)
-├─ Genome(OTU_97.11114.0)
-├─ Genome(OTU_97.10083.0)
-├─ Genome(OTU_97.9999.0)
-├─ Genome(OTU_97.36230.0)
-└─ Genome(OTU_97.30020.0)
+Species "D", 2 genomes
+├─ Genome(gA)
+└─ Genome(gB)
 ```
 
 The parent is an instance of a `Clade`.
@@ -166,80 +150,49 @@ Conceptually, rank zero corresponds to `Genome`s (OTUs, for this reference datas
 
 ```jldoctest walk
 julia> clade.children
-6-element Vector{Genome}:
- Genome(OTU_97.36230.1)
- Genome(OTU_97.11114.0)
- Genome(OTU_97.10083.0)
- Genome(OTU_97.9999.0)
- Genome(OTU_97.36230.0)
- Genome(OTU_97.30020.0)
+2-element Vector{Genome}:
+ Genome(gA)
+ Genome(gB)
 ```
 
-We can find the most recent common ancestor (MRCA) of `genome` and `g2` like this:
+We can find the most recent common ancestor (MRCA) of `genome` and `genome2` like this:
 ```jldoctest walk
 julia> mrca(genome, genome2)
-Domain "Bacteria", 1394 genomes
-├─ Phylum "Deinococcus-Thermus", 12 genomes
-│  └─ Class "Deinococci", 12 genomes
-│     └─ Order "Deinococcales", 12 genomes
-│        ⋮
-│
-├─ Phylum "Tenericutes", 5 genomes
-│  └─ Class "Mollicutes", 5 genomes
-│     └─ Order "Mycoplasmatales", 5 genomes
-│        ⋮
-│
-├─ Phylum "Fusobacteria", 21 genomes
-│  └─ Class "Fusobacteriia", 21 genomes
-│     └─ Order "Fusobacteriales", 21 genomes
-│        ⋮
-│
-├─ Phylum "Bacteroidetes", 85 genomes
-│  ├─ Class "Sphingobacteriia", 1 genome
-│  │  └─ Order "Sphingobacteriales", 1 genome
-│  │     ⋮
-│  │
-│  ├─ Class "Bacteroidia", 47 genomes
-│  │  └─ Order "Bacteroidales", 47 genomes
-│  │     ⋮
-│  │
-⋮
+Species "D", 2 genomes
+├─ Genome(gA)
+└─ Genome(gB)
 ```
 
 They are very distantly related, so the domain "Bacteria", one of the highest ranked `Clade`s, are their most recent common ancestor.
 
-The top clade can be found with the `top_clade(ref)` function.
-In our case, the dataset only consists of bacteria and plasmids, and we filtered away all plasmids, so the universal ancestor
-only has one child, namely the domain Bacteria.
+The top clade can be found with the `top_clade(ref)` function, which is the universal ancestor of all clades in the reference.
 
 ## Binnings
 A `Binning` is a set of bins benchmarked against a reference.
 We can load a set of Vamb bins and turn it into a `Binning` object like this:
 
 ```jldoctest walk
-julia> binning = open(bins_path) do io
-           Binning(io, ref; binsplit_separator='C')
-       end
+julia> binning = Binning(path_to_bins_file, ref)
 Binning
   Reference
-    Genomes:    1394
-    Sequences:  118267
-    Ranks:      9
-    Seq length: 1500
-    Assembled:  16.1 %
-  Bins:        14535
-  NC genomes:  10
+    Genomes:    2
+    Sequences:  11
+    Ranks:      3
+    Seq length: 10
+    Assembled:  91.3 %
+  Bins:        6
+  NC genomes:  0
   Precisions: [0.6, 0.7, 0.8, 0.9, 0.95, 0.99]
   Recalls:    [0.6, 0.7, 0.8, 0.9, 0.95, 0.99]
-  Recoverable genomes: [193, 142, 98, 51, 21, 0]
+  Recoverable genomes: [2, 2, 2, 1, 1, 0]
   Reconstruction (assemblies):
     P\R   0.6  0.7  0.8  0.9 0.95 0.99
-    0.6   160  135   87   39   14    4
-    0.7   143  122   80   36   13    3
-    0.8   118  101   71   33   13    3
-    0.9    79   71   55   29   12    3
-    0.95   70   63   50   26   12    3
-    0.99   57   51   39   23   10    2
+    0.6     1    0    0    0    0    0
+    0.7     1    0    0    0    0    0
+    0.8     1    0    0    0    0    0
+    0.9     1    0    0    0    0    0
+    0.95    1    0    0    0    0    0
+    0.99    1    0    0    0    0    0
 ```
 
 A wealth of information is readily available:
@@ -250,7 +203,7 @@ A wealth of information is readily available:
 
 ```jldoctest walk
 julia> println(binning.recoverable_genomes)
-[193, 142, 98, 51, 21, 0]
+[2, 2, 2, 1, 1, 0]
 ```
 
 The function `print_matrix` will display the number of recovered genomes/assemblies.
@@ -261,35 +214,35 @@ not number of recovered assemblies.
 ```jldoctest walk
 julia> print_matrix(binning; level=1, assembly=false)
 P\R   0.6  0.7  0.8  0.9 0.95 0.99
-0.6    62   48   31   10    1    0
-0.7    59   46   30   10    1    0
-0.8    59   46   30   10    1    0
-0.9    59   46   30   10    1    0
-0.95   56   44   30   10    1    0
-0.99   46   37   25    9    1    0
+0.6     1    0    0    0    0    0
+0.7     1    0    0    0    0    0
+0.8     1    0    0    0    0    0
+0.9     1    0    0    0    0    0
+0.95    1    0    0    0    0    0
+0.99    1    0    0    0    0    0
 ```
 
 You can also get the number of genomes or assemblies reconstructed at a given
 precision/recall level directly with `n_recovered`:
 
 ```jldoctest walk
-julia> n_recovered(binning, 0.75, 0.9; assembly=true)
-55
+julia> n_recovered(binning, 0.6, 0.7; assembly=true)
+1
 
 julia> n_recovered(binning, 0.66, 0.91; level=1)
-44
+0
 ```
 
 ## Bins
 The `Binning` object obviously contains our bins.
-Let's pick a particularly good bin:
+Let's pick a random bin:
 
 ```jldoctest walk
-julia> bin = binning.bins[261]
-Bin "S13Cvae_479"
-  Sequences: 47
-  Breadth:   2482216
-  Intersecting 1 genome
+julia> bin = binning.bins[4]
+Bin "C4"
+  Sequences: 3
+  Breadth:   55
+  Intersecting 2 genomes
 ```
 
 The "breadth" here is the sum of the length of its sequences.
@@ -297,50 +250,28 @@ The "breadth" here is the sum of the length of its sequences.
 
 ```jldoctest walk
 julia> collect(bin.sequences)
-47-element Vector{Sequence}:
- Sequence("S13C2748", 73726)
- Sequence("S13C13383", 18077)
- Sequence("S13C59849", 95631)
- Sequence("S13C29443", 13209)
- Sequence("S13C56904", 44356)
- Sequence("S13C14948", 9756)
- Sequence("S13C37848", 19070)
- Sequence("S13C2782", 22054)
- Sequence("S13C40546", 46579)
- Sequence("S13C12978", 15372)
- ⋮
- Sequence("S13C33782", 34963)
- Sequence("S13C27111", 21961)
- Sequence("S13C10862", 55887)
- Sequence("S13C54667", 69970)
- Sequence("S13C19757", 199299)
- Sequence("S13C64535", 73792)
- Sequence("S13C2686", 20376)
- Sequence("S13C62986", 19619)
- Sequence("S13C14459", 39940)
+3-element Vector{Sequence}:
+ Sequence("s5", 25)
+ Sequence("s6", 10)
+ Sequence("s7", 20)
 ```
 
-The "Intersecting 1 genome" means that the sequences map to 1 genome.
+The "Intersecting 2 genomes" means that the sequences map to 2 different genomes - the only two in the reference.
 We can get that with the function [`intersecting`](@ref), then get the precision/recall
 with [`recall_precision`](@ref):
 
 ```jldoctest walk
-julia> intersecting_genome = only(intersecting(bin))
-Genome "OTU_97.9674.1"
-  Parent:        "Corynebacterium humireducens"
-  Genome size:   2714910
-  Assembly size: 2575299 (94.9 %)
-  Sources:       1
-  Flags:         1 (organism)
+julia> Set(intersecting(bin)) == genomes(ref)
+true
 
-julia> recall_precision(only(intersecting(bin)), bin)
-(recall = 0.9614992278566489, precision = 1.0)
+julia> recall_precision(genome2, bin)
+(recall = 0.6122448979591837, precision = 1.0)
 ```
 
-Or do the same for a higher clade - let's say a genus:
+Or do the same for a higher clade - let's say a genus. In this case, we get the same result.
 ```jldoctest walk
 julia> genus = only(Iterators.filter(i -> i.rank == 2, intersecting(Clade, bin)));
 
 julia> recall_precision(genus, bin)
-(recall = 0.9614992278566489, precision = 1.0)
+(recall = 0.6122448979591837, precision = 1.0)
 ```

--- a/src/VambBenchmarks.jl
+++ b/src/VambBenchmarks.jl
@@ -1,6 +1,7 @@
 module VambBenchmarks
 
 using AbstractTrees: AbstractTrees
+using CodecZlib: GzipDecompressorStream
 using JSON3: JSON3
 using StructTypes: StructTypes
 using LazilyInitializedFields: @lazy, @isinit, @init!, @uninit!, uninit

--- a/src/binning.jl
+++ b/src/binning.jl
@@ -2,7 +2,7 @@ const DEFAULT_RECALLS = (0.6, 0.7, 0.8, 0.9, 0.95, 0.99)
 const DEFAULT_PRECISIONS = (0.6, 0.7, 0.8, 0.9, 0.95, 0.99)
 
 """
-    Binning(::IO, ::Reference; kwargs...)
+    Binning(::Union{IO, AbstractString}, ::Reference; kwargs...)
 
 A `Binning` represents a set of `Bin`s benchmarked against a `Reference`.
 `Binning`s can be created given a set of `Bin`s and a `Reference`, where the
@@ -16,7 +16,7 @@ See also: [`print_matrix`](@ref), [`Bin`](@ref), [`Reference`](@ref)
 
 # Examples
 ```jldoctest
-julia> bins = gold_standard(ref);
+julia> bins = Binning(path_to_bins_file, ref);
 
 julia> bins isa Binning
 true
@@ -30,7 +30,7 @@ Create with:
 ```julia
 open(file) do io
     Binning(
-        io::IO,
+        io::Union{IO, AbstractString},
         ref::Reference;
         min_size::Integer=1,
         min_seqs::Integer=1,
@@ -183,6 +183,10 @@ function n_nc(x::Binning)::Union{Int, Nothing}
 end
 
 nbins(x::Binning) = length(x.bins)
+
+function Binning(path::AbstractString, ref::Reference; kwargs...)
+    open_perhaps_gzipped(io -> Binning(io, ref; kwargs...), String(path))
+end
 
 function Binning(
     io::IO,

--- a/src/reference.jl
+++ b/src/reference.jl
@@ -8,7 +8,7 @@
 end
 
 """
-    Reference(::IO; [min_seq_length=1])
+    Reference(::Union{IO, AbstractString}; [min_seq_length=1])
 
 A `Reference` contains the ground truth to benchmark against.
 Conceptually, it consists of the following parts:
@@ -22,9 +22,7 @@ from a JSON file.
 
 # Examples
 ```jldoctest
-julia> ref = open(path_to_ref_file) do io
-           Reference(io; min_seq_length=1)
-       end;
+julia> ref = Reference(path_to_ref_file; min_seq_length=3);
 
 julia> ref isa Reference
 true
@@ -261,6 +259,10 @@ struct ReferenceJSON
     taxmaps::Vector{Vector{Tuple{String, Union{String, Nothing}}}}
 end
 StructTypes.StructType(::Type{ReferenceJSON}) = StructTypes.Struct()
+
+function Reference(path::AbstractString; min_seq_length::Integer=1)
+    open_perhaps_gzipped(i -> Reference(i; min_seq_length), String(path))
+end
 
 function Reference(io::IO; min_seq_length::Integer=1)
     Reference(JSON3.read(io, ReferenceJSON), Int(min_seq_length))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,3 +27,11 @@ function binsplit_tab_pairs(t_pairs, sep::Union{Char, AbstractString})
         (new_binname, seqname)
     end
 end
+
+function open_perhaps_gzipped(f::Function, path::String)
+    if endswith(path, ".gz")
+        open(f, GzipDecompressorStream, path)
+    else
+        open(f, path)
+    end
+end


### PR DESCRIPTION
Allow constructing Reference and Binning from possibly gzipped paths

This commit adds to new elements to the API:
* You can now construct Reference and Binning directly from paths, like so
  `ref = Reference(my_path)`.
* If the path ends in `.gz`, it will be unzipped using gzip.

Update walkthrough to use small example files

Previously, the walkthrough used large, realistic files. This illustrated the use
of VambBenchmarks better, but required these large files to be present on the
computer that built the docs.
Now, use the small example files. I might want to expand these in the future.