### PR TITLE
Set codecov CI threshold to 10%

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 10%
+        base: auto 
+        flags: 
+          - unittest
+        paths: 
+          - "src"
+       # advanced settings
+        if_ci_failed: ignore
+        informational: true


### PR DESCRIPTION
Do not fail CI if codecov changes slightly. Julia codecov is brittle, and varies randomly. This causes tonnes of false positives in CI which is annoying. Now, don't fail CI if codecov falls.