### PR TITLE
Restore JSONSchema test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 AbstractTrees = "0.4.2"
 CodecZlib = "0.7"
 JSON = "1"
+JSONSchema = "1.5"
 LazilyInitializedFields = "1.2"
 PrecompileTools = "1"
 StructTypes = "1.9"
@@ -22,7 +23,8 @@ Test = "1.9"
 julia = "1.9"
 
 [extras]
+JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "JSONSchema"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ using BinBencherBackend:
 
 using CodecZlib: GzipCompressor
 using JSON: JSON
+using JSONSchema: JSONSchema
 
 include("sameref.jl")
 
@@ -414,12 +415,9 @@ end
     @test sources_by_name["subjC3"].assembly_size == 0
 
     # Ref conforms to schema
-    # TODO: Not compatible with JSON.jl v1
-    #=
     schema = JSONSchema.Schema(String(open(read, joinpath(DIR, "schema.json"))))
-    ref_data = copy(JSON.parse(REF_STR))::Dict
+    ref_data = Dict(JSON.parse(REF_STR))
     @test isnothing(JSONSchema.validate(schema, ref_data))
-    =#
 end
 
 @testset "Adjusted rand index" begin


### PR DESCRIPTION
This test was disabled in 6596b104, but the release of JSONSchema v1.5.0 allows us to re-enable it.

Closes #65 